### PR TITLE
Map上のピンの位置調整

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,3 +58,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "devise"
 
 gem "enum_help"
+
+gem "geocoder"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
       activesupport (>= 3.0.0)
     erubi (1.12.0)
     ffi (1.15.5)
+    geocoder (1.8.1)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -245,6 +246,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   devise
   enum_help
+  geocoder
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (~> 3.3)

--- a/app/models/town.rb
+++ b/app/models/town.rb
@@ -1,4 +1,7 @@
 class Town < ApplicationRecord
     
     has_many :posts,dependent: :destroy
+    
+    geocoded_by :town_name
+    after_validation :geocode
 end

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -42,13 +42,17 @@
           zoom: 7,
         });
         //訪問市町村の座標にピンを表示させる
+        <% if @towns.present? %>
         <% @towns.each do |town| %>
-        results = Geocoder.search(town.town_name)
-        marker = new google.maps.Marker({
-          position:  results[0].geometry.location,
-          map: map
-        });
+          var contentString = "<%= town.town_name %>";
+          
+          var marker = new google.maps.Marker({
+            position: {lat: <%= town.latitude %>, lng: <%= town.longitude %>},
+            map: map
+          });
         <% end %>
+        <% end %>
+
       }
       
       

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -43,14 +43,14 @@
         });
         //訪問市町村の座標にピンを表示させる
         <% @towns.each do |town| %>
+        results = Geocoder.search(town.town_name)
         marker = new google.maps.Marker({
-          position:  {lat:<%= town.latitude %>, lng:<%= town.longitude %>},
+          position:  results[0].geometry.location,
           map: map
         });
         <% end %>
       }
       
-      let geocoder
       
       //検索フォームのボタンが押された時に実行
       function codeAddress(){

--- a/app/views/public/posts/new.html.erb
+++ b/app/views/public/posts/new.html.erb
@@ -1,9 +1,9 @@
 <div class="container-fluid">
   <div class="row mt-5 mb-4 d-flex justify-content-center">
-    <h2>ー　<%= @user.user_name %>さんの新たなTabiログ　ー</h2>
+    <div class="h3">ー　<%= @user.user_name %>さんの新たなTabiログ　ー</div>
   </div>
   <div class="row d-flex justify-content-center">
-    <div class="col-sm-7 mr-4">
+    <div class="col-sm-10 col-md-8 col-lg-6 mr-sm-5">
       <%= form_with model: @post,url: public_posts_path,method: :post do |f| %>
       <table class="table table-borderless">
         <colspan>

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,27 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  # lookup: :nominatim,         # name of geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  # use_https: false,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  # api_key: nil,               # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+
+  # Cache configuration
+  # cache_options: {
+  #   expiration: 2.days,
+  #   prefix: 'geocoder:'
+  # }
+)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,12 +12,10 @@ Admin.create!(
 
 require "csv"
 
-CSV.foreach("db/town_data(citypoint).csv") do |info|
+CSV.foreach("db/towndata.csv") do |info|
     Town.create!(
         id: info[0],
-        town_name: info[1],
-        latitude: info[2],
-        longitude: info[3]
+        town_name: info[1]
     )
 end
     


### PR DESCRIPTION
市町村の位置にずれが生じていたので、市町村役場の位置にピンを立てるように調整した
・seedファイルにあった市町村の緯度経度を削除
・gem geocoderを導入し、投稿した際に選んだ市町村名から緯度経度を入手し、カラムに保存